### PR TITLE
Update metrics.md

### DIFF
--- a/sources/metrics.md
+++ b/sources/metrics.md
@@ -1,7 +1,7 @@
 
-## Usage of metrics
+## 측정항목의 사용법
 
-A metric is a function that is used to judge the performance of your model. Metric functions are to be supplied in the `metrics` parameter when a model is compiled. 
+측정항목은 모델의 성능을 평가하는데 사용되는 함수입니다. 측정항목 함수는 모델이 컴파일 될 때 `metrics` 매개변수를 통해 공급됩니다.
 
 ```python
 model.compile(loss='mean_squared_error',
@@ -17,21 +17,21 @@ model.compile(loss='mean_squared_error',
               metrics=[metrics.mae, metrics.categorical_accuracy])
 ```
 
-A metric function is similar to a [loss function](/losses), except that the results from evaluating a metric are not used when training the model. You may use any of the loss functions as a metric function.
+측정항목 함수는 [loss function](/losses)와 비슷하지만, 측정항목을 평가한 결과는 모델을 학습시키는데 사용되지 않는다는 점에서 다릅니다. 어느 손실 함수나 측정항목 함수로 사용할 수 있습니다.
 
-You can either pass the name of an existing metric, or pass a Theano/TensorFlow symbolic function (see [Custom metrics](#custom-metrics)).
+기존의 측정항목의 이름을 전달하거나 Theano/TensorFlow 심볼릭 함수를 전달하시면 됩니다. ([Custom metrics](#custom-metrics)를 참조하십시오)
 
-#### Arguments
-  - __y_true__: True labels. Theano/TensorFlow tensor.
-  - __y_pred__: Predictions. Theano/TensorFlow tensor of the same shape as y_true.
+#### 인수
+  - __y_true__: 참 라벨. Theano/TensorFlow 텐서.
+  - __y_pred__: 예측. y_true와 같은 형태를 취하는 Theano/TensorFlow 텐서.
 
-#### Returns
-  Single tensor value representing the mean of the output array across all
-  datapoints.
+#### 반환값
+  모든 데이터포인트에 대한 아웃풋 배열의 평균을 나타내는
+  하나의 텐서 값.
 
 ----
 
-## Available metrics
+## 사용가능한 측정항목
 
 
 ### binary_accuracy
@@ -78,15 +78,15 @@ keras.metrics.sparse_top_k_categorical_accuracy(y_true, y_pred, k=5)
 ```
 
 
-In addition to the metrics above, you may use any of the loss functions described in the [loss function](/losses) page as metrics.
+위의 측정항목 외에도, [loss function](/losses) 페이지에 기술된 어떠한 손실 함수를 사용해도 좋습니다.
 
 ----
 
-## Custom metrics
+## 커스텀 측정항목
 
-Custom metrics can be passed at the compilation step. The
-function would need to take `(y_true, y_pred)` as arguments and return
-a single tensor value.
+컴파일 단계에서 커스텀 측정항목을 전달할 수 있습니다.
+커스텀 측정항목 함수는 `(y_true, y_pred)`를 인수로 받아야 하며
+하나의 텐서 값을 반환해야 합니다.
 
 ```python
 import keras.backend as K


### PR DESCRIPTION
#70 'metrics'는 머신러닝 용어집을 참고하여 측정항목으로 통칭했습니다.
25 라인의 true label은 부득이 참 라벨로 바꿨습니다.
(metrics.md 마무리)