### PR TITLE
Update scikit-learn-api.md

### DIFF
--- a/sources/scikit-learn-api.md
+++ b/sources/scikit-learn-api.md
@@ -39,7 +39,7 @@
 3. `keras.models.Sequential`, `fit`, `predict`, `predict_proba`, `score` 메소드의
  기본값
 
-scikit-learn의 `grid_search` API를 사용하는 경우, 'sk_params'에 전달되는 모델 생성 및 학습에 사용되는 매개변수는 
+scikit-learn의 `grid_search` API를 사용하는 경우, `sk_params`에 전달되는 모델 생성 및 학습에 사용되는 매개변수는 
 조정 가능한 매개변수 입니다.
 다시 말해, `grid_search`를 사용하여
 최적의 `batch_size`나 `epochs`, 그리고 모델 매개변수를 찾아낼 수 있습니다.

--- a/sources/scikit-learn-api.md
+++ b/sources/scikit-learn-api.md
@@ -29,11 +29,11 @@
 기본값을 넣도록 하여, `sk_params`에 따로 값을 전달하지 않고 에스티메이터를 만들 수 있도록 한다는 점을
 참고하십시오.
 
-`sk_params`는 또한 `fit`, `predict`, `predict_proba`, 그리고 `score` 메소드를
+`sk_params`는 또한 `fit`, `predict`, `predict_proba`, `score` 메소드를
 호출하는데 필요한 매개변수를 전달받습니다(예시: `epochs`, `batch_size`).
 조정(예측) 매개변수는 다음과 같은 순서로 선택됩니다.
 
-1. `fit`, `predict`, `predict_proba`, and `score` 메소드에 
+1. `fit`, `predict`, `predict_proba`, `score` 메소드에 
 등록된 값들
 2. `sk_params`에 전달되는 값
 3. `keras.models.Sequential`, `fit`, `predict`, `predict_proba`, `score` 메소드의

--- a/sources/scikit-learn-api.md
+++ b/sources/scikit-learn-api.md
@@ -1,4 +1,4 @@
-# Scikit-Learn API의 래퍼<sub>Wrappers for the Scikit-Learn API</sub>
+# Scikit-Learn API의 래퍼
 
 `keras.wrappers.scikit_learn.py`의 래퍼를 통해 `Sequential` 케라스 모델을 (단일 입력에 한정하여) Scikit-Learn 작업의 일부로 사용할 수 있습니다.
 
@@ -8,10 +8,10 @@
 
 `keras.wrappers.scikit_learn.KerasRegressor(build_fn=None, **sk_params)`는 Scikit-Learn 회귀 인터페이스를 시행합니다.
 
-### 인수
+### 인자
 
 - __build_fn__: 호출가능한 함수 혹은 클래스 인스턴스
-- __sk_params__: 모델 매개변수 & 매개변수 조정
+- __sk_params__: 모델 생성 및 학습에 사용되는 매개변수(아래 `sk_params`설명 참조) 
 
 `build_fn`은 케라스 모델을 생성하고, 컴파일하고, 반환하여, 
 모델이 학습/예측할 수 있도록 합니다.
@@ -24,8 +24,8 @@
 기본 `build_fn`이 됩니다.
 
 `sk_params`는 모델 매개변수와 조정 매개변수 둘 모두 전달받습니다.
-유효한 모델 매개변수는 `build_fn`의 인수입니다.
-`build_fn`은 scikit-learn의 다른 에스티메이터처럼 의무적으로 인수에 대한
+유효한 모델 매개변수는 `build_fn`의 인자입니다.
+`build_fn`은 scikit-learn의 다른 에스티메이터처럼 의무적으로 인자에 대한
 기본값을 넣도록 하여, `sk_params`에 따로 값을 전달하지 않고 에스티메이터를 만들 수 있도록 한다는 점을
 참고하십시오.
 
@@ -33,13 +33,13 @@
 호출하는데 필요한 매개변수를 전달받습니다(예시: `epochs`, `batch_size`).
 조정(예측) 매개변수는 다음과 같은 순서로 선택됩니다.
 
-1. `fit`, `predict`, `predict_proba`, and `score` 메소드의
-딕셔너리 인수에 전달되는 값
+1. `fit`, `predict`, `predict_proba`, and `score` 메소드에 
+등록된 값들
 2. `sk_params`에 전달되는 값
-3. `keras.models.Sequential`, `fit`, `predict`, `predict_proba`와 `score` 메소드의
+3. `keras.models.Sequential`, `fit`, `predict`, `predict_proba`, `score` 메소드의
  기본값
 
-scikit-learn의 `grid_search` API를 사용하는 경우, 조정 매개변수를 포함한 `sk_params`에 전달하는 매개변수가
-튜닝 가능한 매개변수입니다.
+scikit-learn의 `grid_search` API를 사용하는 경우, 'sk_params'에 전달되는 모델 생성 및 학습에 사용되는 매개변수는 
+조정 가능한 매개변수 입니다.
 다시 말해, `grid_search`를 사용하여
 최적의 `batch_size`나 `epochs`, 그리고 모델 매개변수를 찾아낼 수 있습니다.

--- a/sources/scikit-learn-api.md
+++ b/sources/scikit-learn-api.md
@@ -1,8 +1,8 @@
-# Scikit-Learn API의 래퍼
+# Scikit-Learn API의 래퍼<sub>Wrappers for the Scikit-Learn API</sub>
 
-`keras.wrappers.scikit_learn.py`의 래퍼를 통해 `Sequential` 케라스 모델을 (단일 인풋에 한정하여) Scikit-Learn 작업의 일부로 사용할 수 있습니다.
+`keras.wrappers.scikit_learn.py`의 래퍼를 통해 `Sequential` 케라스 모델을 (단일 입력에 한정하여) Scikit-Learn 작업의 일부로 사용할 수 있습니다.
 
-두가지 래퍼가 이용가능합니다:
+두 가지 래퍼가 이용가능합니다
 
 `keras.wrappers.scikit_learn.KerasClassifier(build_fn=None, **sk_params)`는 Scikit-Learn 분류 인터페이스를 시행하고,
 
@@ -10,34 +10,34 @@
 
 ### 인수
 
-- __build_fn__: 호출가능한 함수 혹은 클레스 인스턴스
+- __build_fn__: 호출가능한 함수 혹은 클래스 인스턴스
 - __sk_params__: 모델 매개변수 & 매개변수 조정
 
 `build_fn`은 케라스 모델을 생성하고, 컴파일하고, 반환하여, 
 모델이 학습/예측할 수 있도록 합니다.
-`build_fn`은 다음의 세가지 값 중 하나를 전달받습니다:
+`build_fn`은 다음의 세 가지 값 중 하나를 전달받습니다.
 
 1. 함수
 2. `__call__` 메소드를 시행하는 클래스의 인스턴스
 3. 비워두기. 이는 `KerasClassifier` 혹은 `KerasRegressor`를 상속받는 클래스를
 만들어야 함을 뜻합니다. 이 경우 현재 클래스의 `__call__` 메소드가
-디폴트 `build_fn`이 됩니다.
+기본 `build_fn`이 됩니다.
 
 `sk_params`는 모델 매개변수와 조정 매개변수 둘 모두 전달받습니다.
 유효한 모델 매개변수는 `build_fn`의 인수입니다.
 `build_fn`은 scikit-learn의 다른 에스티메이터처럼 의무적으로 인수에 대한
-디폴트 값을 넣도록 하여, `sk_params`에 따로 값을 전달하지 않고 에스티메이터를 만들 수 있도록 한다는 점을
+기본값을 넣도록 하여, `sk_params`에 따로 값을 전달하지 않고 에스티메이터를 만들 수 있도록 한다는 점을
 참고하십시오.
 
 `sk_params`는 또한 `fit`, `predict`, `predict_proba`, 그리고 `score` 메소드를
-호출하는데 필요한 매개변수를 전달받습니다(예시., `epochs`, `batch_size`).
-조정(예측) 매개변수는 다음과 같은 순서로 선택됩니다:
+호출하는데 필요한 매개변수를 전달받습니다(예시: `epochs`, `batch_size`).
+조정(예측) 매개변수는 다음과 같은 순서로 선택됩니다.
 
 1. `fit`, `predict`, `predict_proba`, and `score` 메소드의
 딕셔너리 인수에 전달되는 값
 2. `sk_params`에 전달되는 값
 3. `keras.models.Sequential`, `fit`, `predict`, `predict_proba`와 `score` 메소드의
- 디폴트 값
+ 기본값
 
 scikit-learn의 `grid_search` API를 사용하는 경우, 조정 매개변수를 포함한 `sk_params`에 전달하는 매개변수가
 튜닝 가능한 매개변수입니다.


### PR DESCRIPTION
#156

단어논의 결과에 맞게 단어수정 하였습니다.
내용 수정도 함께 하였습니다.(10/13)
~~내용 수정은 향후 진행하겠습니다.~~
수정한 내용은 아래와 같습니다.

- 자잘한 오타 및 띄어쓰기 수정
~~- 제목에 원문 subscription 추가~~
- 인풋 -> 입력
- 콜론(:) 제거
- 디폴트 -> 기본
- 예시., -> 예시:
- 인수 -> 인자(10/13)
- "sk_params"관련 부분 번역이 애매한 부분 준영님 도움을 받아 내용 수정 함께하였습니다.

~~아직 논의가 더 필요한 부분이 있는데, 일단 남겨놓겠습니다.~~
~~1) fitting parameter를 매개변수 '조정'으로 번역하였는데, 뒤에 tunable parameter라는 부분이 있어 '조정'이라는 단어 사용에 대해 논의가 필요합니다.~~
~~2) dictionary arguments -> 이전 번역에는 딕셔너리 인수라고 하였는데... 어떻게 하면 좋을까요 도와주세요 ㅎㅎ~~
