### PR TITLE
update Visualize.md(apply reviewer's comment)

### DIFF
--- a/sources/visualization.md
+++ b/sources/visualization.md
@@ -10,7 +10,7 @@ plot_model(model, to_file='model.png')
 
 `plot_model`은 네 가지 인자를 전달받습니다:
 
-- `show_shapes`(기본값은 `False`)는 결과의 형태을 그래프에 나타낼지 여부를 설정합니다.
+- `show_shapes`(기본값은 `False`)는 결과의 형태을 그래프에 나타낼 것인지 여부를 설정합니다.
 - `show_layer_names`(기본값은 `True`)는 층의 이름을 그래프에 나타낼 것인지 여부를 설정합니다.
 - `expand_nested`(기본값은 `False`)는 중첩된 모델을 그래프상에서 클러스터로 확장할 것인지 여부를 설정합니다.
 - `dpi`(기본값은 96)는 이미지 dpi를 설정합니다.

--- a/sources/visualization.md
+++ b/sources/visualization.md
@@ -10,10 +10,10 @@ plot_model(model, to_file='model.png')
 
 `plot_model`은 네 가지 인자를 전달받습니다:
 
-- `show_shapes`(기본값은 `False`)는 결과의 형태을 그래프에 나타낼 것인지 조정합니다.
-- `show_layer_names`(기본값은 `True`)는 층의 이름을 그래프에 나타낼 것인지 조정합니다.
-- `expand_nested`(기본값은 `False`)는 중첩된 모델을 그래프상에서 클러스터로 확장할 것인지 조정합니다.
-- `dpi`(기본값은 96)는 이미지 dpi를 조정합니다.
+- `show_shapes`(기본값은 `False`)는 결과의 형태을 그래프에 나타낼지 여부를 설정합니다.
+- `show_layer_names`(기본값은 `True`)는 층의 이름을 그래프에 나타낼 것인지 여부를 설정합니다.
+- `expand_nested`(기본값은 `False`)는 중첩된 모델을 그래프상에서 클러스터로 확장할 것인지 여부를 설정합니다.
+- `dpi`(기본값은 96)는 이미지 dpi를 설정합니다.
 
 또한 직접 `pydot.Graph`오브젝트를 만들어 사용할 수도 있습니다, 
 예를들어 ipython notebook에 나타내자면 :


### PR DESCRIPTION
**Apply reviewer's comment**
- 인자(argument)의 설명에서 값을 설정한다는 의미의 control 번역시, '조정' 대신 '설정'으로 사용함.
- review 내용과 다른 문서의 번역내용을 참고하여 수정하였습니다.